### PR TITLE
Support string auths like the readme says

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -5,6 +5,11 @@ var request = require('./request');
 
 module.exports = function(server, io, options) {
   var strategies = options.auth.strategies;
+  
+  // if a raw string is passed in, use that (as per README.md)
+  if (typeof options.auth === 'string') {
+    strategies = [options.auth];
+  }
 
   if (!strategies && options.auth.strategy) {
     strategies = [options.auth.strategy];


### PR DESCRIPTION
The readme says that auth can be a string, however it currently must be an object either either strategy or strategies. This fixes the api to match the documentation.
