### PR TITLE
Adding The Ability To Use socket.io Namespaces

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ var _ = require('lodash');
 var socketio = require('socket.io');
 var auth = require('./auth');
 var routes = require('./routes');
+var namespaces = require('./namespaces');
 
 // Declare internals
 
@@ -20,7 +21,7 @@ exports.register = function(server, options, next) {
   _.defaults(options, internals.defaults);
 
   var s = options.connectionLabel ?
-          server.select(options.connectionLabel) : server;
+      server.select(options.connectionLabel) : server;
 
   if (!s) {
     return next('hapi-io - no server');
@@ -42,6 +43,8 @@ exports.register = function(server, options, next) {
 
   var io = socketio(connection.listener, options.socketio);
 
+  var nsps = namespaces(s,io, options.namespaces);
+
   s.expose('io', io);
 
   s.ext('onRequest', function(request, reply) {
@@ -57,8 +60,10 @@ exports.register = function(server, options, next) {
     auth(s, io, options);
   }
 
-  io.on('connection', function(socket) {
-    routes(s, socket);
+  _.forEach(nsps, function(nsp, namespace) {
+    nsp.on('connection', function(socket) {
+      routes(s, socket, namespace);
+    });
   });
 
   next();

--- a/lib/namespaces.js
+++ b/lib/namespaces.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = function(server, io, namespaces) {
+
+    var nsps = {};
+
+    nsps["/"] = io.of('/');
+
+    if (Array.isArray(namespaces)) {
+        namespaces.forEach(function(namespace) {
+            if (!nsps[namespace]) {
+                nsps[namespace] = io.of(namespace);
+            }
+        });
+    }
+
+    return nsps;
+
+};

--- a/lib/namespaces.js
+++ b/lib/namespaces.js
@@ -4,7 +4,7 @@ module.exports = function(server, io, namespaces) {
 
     var nsps = {};
 
-    nsps["/"] = io.of('/');
+    nsps['/'] = io.of('/');
 
     if (Array.isArray(namespaces)) {
         namespaces.forEach(function(namespace) {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -2,70 +2,73 @@
 
 var request = require('./request');
 
-module.exports = function(server, socket) {
+module.exports = function(server, socket, socketNamespace) {
   var routingTable = server.table();
 
   routingTable.forEach(function(connection) {
     var routes = connection.table.filter(function(item) {
       return item.settings &&
-             item.settings.plugins &&
-             item.settings.plugins['hapi-io'];
+          item.settings.plugins &&
+          item.settings.plugins['hapi-io'];
     });
 
     routes.forEach(function(route) {
       var hapiio = route.settings.plugins['hapi-io'];
       var event = typeof hapiio === 'string' ? hapiio : hapiio.event;
+      var namespace = (!(typeof hapiio === 'string') && !(typeof hapiio.namespace === 'string')) ? "/" : hapiio.namespace;
 
-      socket.on(event, function(data, respond) {
-        if (typeof data === 'function') {
-          respond = data;
-          data = undefined;
-        }
-
-        var req = request({ socket: socket, route: route, data: data });
-
-        server.inject(req, function(res) {
-
-          var responder = function(err, result) {
-            if (!respond) {
-              return;
-            }
-
-            if (err) {
-              // Should we be responding with the error?
-              return respond(err);
-            }
-
-            respond(result || res.result);
-          };
-
-          var context = {
-            io: server.plugins['hapi-io'].io,
-            socket: socket,
-            event: event,
-            data: data,
-            req: req,
-            res: res,
-            result: res.result,
-            trigger: function(_event, _data, nsp) {
-              var packet = {
-                type: 2,
-                nsp: nsp || '/',
-                id: -1,
-                data: [_event, _data]
-              };
-
-              socket.onevent(packet);
-            }
-          };
-
-          if (hapiio.post) {
-            return hapiio.post(context, responder);
+      if (namespace == socketNamespace) {
+        socket.on(event, function (data, respond) {
+          if (typeof data === 'function') {
+            respond = data;
+            data = undefined;
           }
 
-          return responder();
+          var req = request({socket: socket, route: route, data: data});
+
+          server.inject(req, function (res) {
+
+            var responder = function (err, result) {
+              if (!respond) {
+                return;
+              }
+
+              if (err) {
+                // Should we be responding with the error?
+                return respond(err);
+              }
+
+              respond(result || res.result);
+            };
+
+            var context = {
+              io: server.plugins['hapi-io'].io,
+              socket: socket,
+              event: event,
+              data: data,
+              req: req,
+              res: res,
+              result: res.result,
+              trigger: function (_event, _data, nsp) {
+                var packet = {
+                  type: 2,
+                  nsp: nsp || '/',
+                  id: -1,
+                  data: [_event, _data]
+                };
+
+                socket.onevent(packet);
+              }
+            };
+
+            if (hapiio.post) {
+              return hapiio.post(context, responder);
+            }
+
+            return responder();
+          });
         });
-      });
+      }
     });
   });
 };

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -15,7 +15,7 @@ module.exports = function(server, socket, socketNamespace) {
     routes.forEach(function(route) {
       var hapiio = route.settings.plugins['hapi-io'];
       var event = typeof hapiio === 'string' ? hapiio : hapiio.event;
-      var namespace = (!(typeof hapiio === 'string') && !(typeof hapiio.namespace === 'string')) ? "/" : hapiio.namespace;
+      var namespace = (!(typeof hapiio === 'string') && !(typeof hapiio.namespace === 'string')) ? '/' : hapiio.namespace;
 
       if (namespace == socketNamespace) {
         socket.on(event, function (data, respond) {


### PR DESCRIPTION
See issue #33 regarding use of this plugin with namespaces.  This pull request allows for use of the plugin while being fully backwards compatible with existing functionality (no breaking changes).
- If namespaces are to be used, can be defined at plugin time via the "namespaces" option. Any number of namespaces can be used and must be prefixed with a "/".
- If namespaces are used, to have a route respond to a message sent on a namespace socket, the individual route must have the "namespace" option specified with a valid namespace. The default socket.io namespace of "/" can be explicitly specified however a route will automatically included in "/" if "namesapce" is not specified for the route.
- Readme documentation updated to reflect additional of new functionality via new plugin/route options.
